### PR TITLE
Improved performance of BSON::_decode_cstring

### DIFF
--- a/lib/Mango/BSON.pm
+++ b/lib/Mango/BSON.pm
@@ -138,8 +138,8 @@ sub _decode_binary {
 
 sub _decode_cstring {
   my $bsonref = shift;
-  (my $str, $$bsonref) = unpack 'Z*a*', $$bsonref;
-  return decode 'UTF-8', $str;
+  $$bsonref =~ s/^([^\x{00}]*)\x{00}?//;
+  return decode 'UTF-8', $1;
 }
 
 sub _decode_doc {


### PR DESCRIPTION
Decoding large BSON objects are a bit slower in Mango. I tried to speed up the function _decode_cstring, getting rid of excess memory copy using unpack.

Logs of NYTProf with the old version _decode_cstring:

``` text
Profile of analyze.pl for 37.9s (of 42.1s), executing 1824734 statements and 861662 subroutine calls in 88 source files and 81 string evals.

50197   1   1   14.2s   29.5s             Mango::BSON::_decode_cstring
100397  4   1   13.1s   13.1s             Mango::BSON::CORE:unpack (opcode)
100368  2   1   2.37s   4.23s              Mojo::Util::decode
18  3   1   1.78s   37.4s             Mango::BSON::_decode_doc (recurses: max depth 3, inclusive time 111s)
50197   1   1   1.40s   37.4s             Mango::BSON::_decode_value (recurses: max depth 3, inclusive time 78.7s)
100368  1   1   1.06s   1.48s            Encode::utf8::decode_xs (xsub)
50171   1   1   1.04s   3.42s             Mango::BSON::_decode_string
50203   3   2   758ms   758ms   Mango::BSON::Document::STORE
50198   7   2   424ms   553ms             Mango::BSON::decode_int32
100368  1   1   417ms   417ms        Encode::Encoding::renewed
100391  2   1   389ms   389ms              Mojo::Util::_encoding
50180   4   3   297ms   297ms   Mango::BSON::Document::FETCH
17  1   1   292ms   292ms                IO::Poll::_poll (xsub)
50188   3   2   210ms   210ms   Mango::BSON::Document::NEXTKEY
1   1   1   30.0ms  63.2ms  Mango::BSON::ObjectID::BEGIN@5
```

Logs of NYTProf with the new version _decode_cstring:

``` text
Profile of analyze.pl for 18.7s (of 22.6s), executing 1824734 statements and 861662 subroutine calls in 88 source files and 81 string evals.


50197   1   1   7.93s   7.93s             Mango::BSON::CORE:subst (opcode)
100368  2   1   2.13s   3.79s              Mojo::Util::decode
18  3   1   1.54s   18.1s             Mango::BSON::_decode_doc (recurses: max depth 3, inclusive time 52.9s)
50197   1   1   1.33s   18.1s             Mango::BSON::_decode_value (recurses: max depth 3, inclusive time 40.0s)
50171   1   1   997ms   3.34s             Mango::BSON::_decode_string
100368  1   1   954ms   1.32s            Encode::utf8::decode_xs (xsub)
50197   1   1   849ms   10.7s             Mango::BSON::_decode_cstring
50203   3   2   663ms   663ms   Mango::BSON::Document::STORE
50198   7   2   394ms   492ms             Mango::BSON::decode_int32
100368  1   1   369ms   369ms        Encode::Encoding::renewed
100391  2   1   336ms   337ms              Mojo::Util::_encoding
17  1   1   302ms   302ms                IO::Poll::_poll (xsub)
50180   4   3   299ms   299ms   Mango::BSON::Document::FETCH
50188   3   2   210ms   210ms   Mango::BSON::Document::NEXTKEY
50200   3   1   98.1ms  98.1ms            Mango::BSON::CORE:unpack (opcode)
```
