### PR TITLE
Improved performance of BSON parser

### DIFF
--- a/lib/Mango/BSON.pm
+++ b/lib/Mango/BSON.pm
@@ -77,7 +77,7 @@ sub bson_decode {
 
 sub bson_doc {
   tie my %hash, 'Mango::BSON::Document', @_;
-  return \%hash;
+  \%hash;
 }
 
 sub bson_encode {
@@ -94,10 +94,7 @@ sub bson_encode {
 
 sub bson_false {$FALSE}
 
-sub bson_length {
-  my $bson = shift;
-  return length($bson) < 4 ? undef : decode_int32(substr $bson, 0, 4);
-}
+sub bson_length { decode_int32(substr $_[0], 0, 4); }
 
 sub bson_max {$MAXKEY}
 
@@ -113,8 +110,8 @@ sub bson_ts {
 
 sub bson_true {$TRUE}
 
-sub decode_int32 { 0 + unpack 'l<', shift }
-sub decode_int64 { 0 + unpack 'q<', shift }
+sub decode_int32 { unpack 'l<', shift }
+sub decode_int64 { unpack 'q<', shift }
 
 sub encode_cstring { pack 'Z*', encode('UTF-8', shift) }
 
@@ -137,9 +134,8 @@ sub _decode_binary {
 }
 
 sub _decode_cstring {
-  my $bsonref = shift;
-  $$bsonref =~ s/^([^\x00]*)\x00//;
-  return decode 'UTF-8', $1;
+  ${$_[0]} =~ s/^([^\x00]*)\x00//;
+  $1;
 }
 
 sub _decode_doc {
@@ -178,7 +174,7 @@ sub _decode_value {
     if $type eq OBJECT_ID;
 
   # Double/Int32/Int64
-  return 0 + unpack 'd<', substr $$bsonref, 0, 8, '' if $type eq DOUBLE;
+  return unpack 'd<', substr $$bsonref, 0, 8, '' if $type eq DOUBLE;
   return decode_int32(substr $$bsonref, 0, 4, '') if $type eq INT32;
   return decode_int64(substr $$bsonref, 0, 8, '') if $type eq INT64;
 

--- a/lib/Mango/Cursor.pm
+++ b/lib/Mango/Cursor.pm
@@ -157,16 +157,15 @@ sub _dequeue {
   my $self = shift;
   return undef if $self->_finished;
   $self->{num}++;
-  return shift @{$self->{results}};
+  shift @{$self->{results}};
 }
 
 sub _enough { $_[0]->_finished ? 1 : !!@{$_[0]{results}} }
 
 sub _finished {
   my $self = shift;
-  return undef unless my $limit = $self->limit;
-  $limit = $limit * -1 if $limit < 0;
-  return ($self->{num} // 0) >= $limit ? 1 : undef;
+  return undef unless $self->limit;
+  return ($self->{num} // 0) >= abs($self->limit) ? 1 : undef;
 }
 
 sub _enqueue {


### PR DESCRIPTION
Hello, Sebastian.

1) I removed the conversion to numbers in the functions `decode_int32` and `decode_int64`. So much so that extra conversion steps that affect performance. (test: https://gist.github.com/avkhozov/5993752). Although in this case, if the document is smaller than the required number of bytes, undef is returned. I believe undef more correct than 0.

2) I deleted the decoding of bytes in the UTF-8 string in a `_decode_cstring` function, since the function `decode` of the module `Mojo::Util` works with checks on the validity of the encoding, which slows down its operation. I believe that cstring is always are ASCII string, not a UTF-8 string. Not every UTF-8 string can be the key in BSON document.

3) I rewrote the implementation of ordered hash with only one internal array of keys, without an array of values. Now remove the item from such hash runs in linear time, which I think is not critical for BSON documents (since they are usually small and the delete operator is not too frequent), but STORE and FETCH operations are faster and the documents themselves take up less memory.

With such changes on some tests, I got a performance gain of 40%. However, this implementation is slower than the official driver about twice.

Thanks.
