### PR TITLE
fixed bug when methods of a Mango::Collection object passed Mango::Datab...

### DIFF
--- a/lib/Mango/Collection.pm
+++ b/lib/Mango/Collection.pm
@@ -224,7 +224,7 @@ sub _command {
   my $protocol = $db->mango->protocol;
   return $db->command(
     $command => sub {
-      my ($self, $err, $doc) = @_;
+      my ($db, $err, $doc) = @_;
       $err ||= $protocol->write_error($doc);
       $self->$cb($err, $return->($doc));
     }


### PR DESCRIPTION
``` perl
$collection->insert({foo => 2}, sub { my $self = shift; })
```

$self must be a Mango::Collection object, not Mango::Database. This commit fix it and add tests to avoid that in the future
