### PR TITLE
Numberize - treat numbers as perl does

### DIFF
--- a/t/bson.t
+++ b/t/bson.t
@@ -399,4 +399,13 @@ like $@, qr/Invalid object id "123456789012345678abcdgf"/, 'invalid object id';
 eval { bson_oid(0) };
 like $@, qr/Invalid object id "0"/, 'invalid object id';
 
+# numberize
+is bson_encode({foo => 1}), bson_encode({foo => '1'}, 1);
+isnt bson_encode({foo => 1}), bson_encode({foo => '1'});
+
+# more complex numberize
+my $doc_num = bson_doc(a => 1,   f => {b => -1},   c => [1.1,   0,   -0.1]);
+my $doc_str = bson_doc(a => '1', f => {b => '-1'}, c => ['1.1', '0', '-0.1']);
+is bson_encode($doc_num), bson_encode($doc_str, 1);
+
 done_testing();


### PR DESCRIPTION
Ability to treat the numbers as perl does
bson_encode({one => '1'}, 1)
will be the same as
bson_encode({one => 1})

There will be no need to do something like this:
my $var = $c->param('var');
$var+=0;

I think without that option perl programmers will have a headache in the real world. If it will be applied, we'll be able to add  a 'numberize' attribute for Mango::Collection. I've founded that word, but my English isn't good enough, so it may sound a little weird.

Surprisingly, when I changed the default value to 1, all tests had passed ok o_0. But I think it would be better to leave it as it is now. 
