### PR TITLE
Mango::BSON::_encode_object: TO_BSON

### DIFF
--- a/lib/Mango/BSON.pm
+++ b/lib/Mango/BSON.pm
@@ -288,8 +288,8 @@ sub _encode_object {
     $value->seconds
     if $class eq 'Mango::BSON::Timestamp';
 
-  # Blessed reference with TO_JSON method
-  if (my $sub = $value->can('TO_JSON')) {
+  # Blessed reference with a TO_BSON or TO_JSON method
+  if (my $sub = $value->can('TO_BSON') || $value->can('TO_JSON')) {
     return _encode_value($e, $value->$sub);
   }
 


### PR DESCRIPTION
Permit object encoding to preferentially request a different representation for storage vs JSON from blessed objects.

Due to the schema-less nature of MongoDB, all "schema" is stored on a record by record basis. There is a fair deal of overhead in large implementations and it is best practice to use short field names.

Ie. All data is stored in MongoDB and in the blessed object using 2-3 character field names, but for readability all output representations (XML, JSON, or object accessors) use long human readable variations.

Eg:

``` perl
$obj->account('@user')->email('user@example.com');
$obj->TO_JSON;
# { account => '@user', email => 'user@example.com' }

$obj->TO_BSON;
# { ac => '@user', e => 'user@example.com' }
```

I had worked with Mike Friedman to have this same functionality added to MongoDB's perl driver with the inclusion of a non-recursive encoding algorithm, although I've not been able to find the status of said request.
