### PR TITLE
Remove defaults from query and fields methods

### DIFF
--- a/lib/Mango/Cursor/Query.pm
+++ b/lib/Mango/Cursor/Query.pm
@@ -7,7 +7,7 @@ has [
   qw(await_data comment hint max_scan max_time_ms read_preference snapshot),
   qw(sort tailable)
 ];
-has [qw(fields query)] => sub { {} };
+has [qw(fields query)];
 has skip => 0;
 
 sub build_query {


### PR DESCRIPTION
It isn't actually a commit, it's more like a question.
I try to use something like this in my models (check if a criteria was set and set a default one if was not).

``` perl
sub default_query { {active => 1} }
sub load {
   my ($self, $cursor) = @_;
   # oops, empty hash is default, wich means find all
   # $cursor->query($self->default_query) unless $cursor->query;
   $cursor->query($self->default_query) unless $cursor->{query};
}
```

By default fields and query attributes are empty hashrefs, so it is impossible to check if query was set to "find any" or if it wasn't set yet. $cursor->{query} works for me, but I think this isn't the best way
